### PR TITLE
C++Builder compatibility

### DIFF
--- a/SynCommons.pas
+++ b/SynCommons.pas
@@ -8634,6 +8634,11 @@ type
     procedure SetParameters(Value: RawUTF8); override;
   end;
 
+  // C++Builder doesn't support array elements as properties (RSP-12595).
+  // For now, simply exclude the relevant classes from C++Builder.
+  {$NODEFINE TSynValidateText }
+  {$NODEFINE TSynValidatePassWord }
+
   /// will define a filter to be applied to a Record field content (typicaly
   // a TSQLRecord)
   // - a typical usage is to convert to lower or upper case, or
@@ -9853,7 +9858,7 @@ type
   {$A-}
   /// used to store a Date/Time in TSynTimeZone internal structures
   // - map Windows.TSystemTime, since it is how it is stored in the Registry
-  TTimeZoneValue = object
+  TTimeZoneValue = {$ifdef ISDELPHI2006ANDUP}record{$else}object{$ifend}
     wYear: Word;
     wMonth: Word;
     wDayOfWeek: Word;
@@ -9877,7 +9882,7 @@ type
   end;
   PTimeZoneInfo = ^TTimeZoneInfo;
   /// used to store Time Zone information for a single area in TSynTimeZone
-  TTimeZoneData = object
+  TTimeZoneData = {$ifdef ISDELPHI2006ANDUP}record{$else}object{$ifend}
     id: RawUTF8;
     display: RawUTF8;
     tzi: TTimeZoneInfo;
@@ -9918,7 +9923,8 @@ type
     // - under Linux, the file should be located with the executable, renamed
     // with a .tz extension - may have been created via SaveToFile(''), or
     // from a 'TSynTimeZone' bound resource
-    constructor CreateDefault;
+    // "dummy" parameter exists only to disambiguate constructors for C++
+    constructor CreateDefault(dummy: integer=0);
     /// finalize the instance
     destructor Destroy; override;
     {$ifdef MSWINDOWS}
@@ -27068,7 +27074,7 @@ begin
   fZones.InitSpecific(TypeInfo(TTimeZoneDataDynArray),fZone,djRawUTF8);
 end;
 
-constructor TSynTimeZone.CreateDefault;
+constructor TSynTimeZone.CreateDefault(dummy: integer);
 begin
   Create;
   {$ifdef LVCL}

--- a/SynPdf.pas
+++ b/SynPdf.pas
@@ -370,6 +370,9 @@ const
   MWT_LEFTMULTIPLY = 2;
   MWT_RIGHTMULTIPLY = 3;
   MWT_SET = 4;
+  {$NODEFINE MWT_IDENTITY}
+  {$NODEFINE MWT_LEFTMULTIPLY}
+  {$NODEFINE MWT_RIGHTMULTIPLY}
 
 {  some low-level record definition for True Type format table reading }
 
@@ -3041,6 +3044,21 @@ function ScriptShape(hdc: HDC; var psc: pointer; const pwcChars: PWideChar;
 function ScriptApplyDigitSubstitution(
     const psds: Pointer; const psControl: pointer;
     const psState: pointer): HRESULT; stdcall; external Usp10;
+
+// C++Builder code should #include <usp10.h> directly instead of using these.
+{$NODEFINE TScriptState }
+{$NODEFINE PScriptState }
+{$NODEFINE TScriptAnalysis }
+{$NODEFINE PScriptAnalysis }
+{$NODEFINE TScriptVisAttr }
+{$NODEFINE PScriptVisAttr }
+{$NODEFINE TScriptItem }
+{$NODEFINE PScriptItem }
+{$NODEFINE ScriptItemize }
+{$NODEFINE ScriptGetProperties }
+{$NODEFINE ScriptLayout }
+{$NODEFINE ScriptShape }
+{$NODEFINE ScriptApplyDigitSubstitution }
 
 {$endif USE_UNISCRIBE}
 

--- a/SynZip.pas
+++ b/SynZip.pas
@@ -729,8 +729,9 @@ type
     // - warning: AddStored/AddDeflated() won't check for duplicate zip entries
     // - this method is very fast, and will increase the .zip file in-place
     // (the old content is not copied, new data is appended at the file end)
+    // "dummy" parameter exists only to disambiguate constructors for C++
     {$ifndef Linux}
-    constructor CreateFrom(const aFileName: TFileName);
+    constructor CreateFrom(const aFileName: TFileName; dummy: integer=0);
     {$endif}
     /// compress (using the deflate method) a file, and add it to the zip file
     procedure AddDeflated(const aFileName: TFileName; RemovePath: boolean=true;
@@ -1032,7 +1033,7 @@ begin
 end;
 
 {$ifndef Linux}
-constructor TZipWrite.CreateFrom(const aFileName: TFileName);
+constructor TZipWrite.CreateFrom(const aFileName: TFileName; dummy: integer);
 var R: TZipRead;
     i: Integer;
 begin


### PR DESCRIPTION
Use NODEFINE for macros, functions, and structs that are already defined in C++
header files.

Use NODEFINE to exclude TSynValidateText and its subclass, since C++Builder
doesn't currently support array properties.

Use "record" where possible, since C++Builder doesn't like "object."

Add dummy parameters where necessary to constructor overloads (Delphi compiler
warning W1029).

See http://synopse.info/forum/viewtopic.php?pid=18151 for more info.