### PR TITLE
Revert change in fixed width condition

### DIFF
--- a/SynPdf.pas
+++ b/SynPdf.pas
@@ -6672,7 +6672,7 @@ begin
   if ALogFont.lfWeight>=FW_SEMIBOLD then
     include(AStyle,pfsBold);
   result := SetFont(AName,ASize,AStyle,ALogFont.lfCharSet,-1,
-    (ALogFont.lfPitchAndFamily and 3) = FIXED_PITCH);
+    ALogFont.lfPitchAndFamily and TMPF_FIXED_PITCH=0);
 end;
 
 procedure TPdfCanvas.TextOut(X, Y: Single; const Text: PDFString);


### PR DESCRIPTION
This reverts a change in commit:
da8902dac344010eaf58340a2c149e63f96319ee
Made on 29 May 2020

Pull request https://github.com/synopse/mORMot/pull/296 changed this line but at least for me it's returning exact the opposite it should, which leads to characters overlapping when using "MS Sans Serif" font.

Tested with "MS Sans Serif" and "Courier New" fonts before my modification, first was evaluated as fixed width (condition returns true) and second as proportional (condition returns false). Should be inverted results. 