### PR TITLE
Added VER370 to GetDelphiCompilerVersion() call to make it build with Delphi 13

### DIFF
--- a/SynCommons.pas
+++ b/SynCommons.pas
@@ -59317,6 +59317,7 @@ begin
     {$elseif defined(VER340)}'Delphi 10.4 Sydney'
     {$elseif defined(VER350)}'Delphi 11 Alexandria'
     {$elseif defined(VER360)}'Delphi 11.1 Next'
+    {$elseif defined(VER370)}'Delphi 13'
     {$ifend}
   {$endif CONDITIONALEXPRESSIONS}
 {$endif FPC}


### PR DESCRIPTION
Added this line to ```SynCommons.pas``` to make it build with Delphi 13

```pascal
    {$elseif defined(VER370)}'Delphi 13'
```